### PR TITLE
Bugfix/mutable const correctness

### DIFF
--- a/args/core/containers/atomic_sparse_map.hpp
+++ b/args/core/containers/atomic_sparse_map.hpp
@@ -54,7 +54,7 @@ namespace args::core
 		using const_iterator = typename dense_value_container::const_iterator;
 
 	private:
-		async::readonly_rw_spinlock m_container_lock;
+		mutable async::readonly_rw_spinlock m_container_lock;
 
 		dense_value_container m_dense_value;
 		dense_key_container m_dense_key;

--- a/args/core/containers/sparse_map.hpp
+++ b/args/core/containers/sparse_map.hpp
@@ -88,7 +88,7 @@ namespace args::core
 		{
 			if (size > m_capacity)
 			{
-		m_dense_value.resize(size);
+				m_dense_value.resize(size);
 				m_dense_key.resize(size);
 				m_capacity = size;
 			}

--- a/args/core/containers/sparse_map.hpp
+++ b/args/core/containers/sparse_map.hpp
@@ -54,11 +54,11 @@ namespace args::core
 		size_type m_capacity = 0;
 
 	public:
-		A_NODISCARD iterator begin() { return m_dense.begin(); }
-		A_NODISCARD const_iterator begin() const { return m_dense.cbegin(); }
+		A_NODISCARD iterator begin() { return m_dense_value.begin(); }
+		A_NODISCARD const_iterator begin() const { return m_dense_value.cbegin(); }
 
-		A_NODISCARD iterator end() { return m_dense.begin() + m_size; }
-		A_NODISCARD const_iterator end() const { return m_dense.cbegin() + m_size; }
+		A_NODISCARD iterator end() { return m_dense_value.begin() + m_size; }
+		A_NODISCARD const_iterator end() const { return m_dense_value.cbegin() + m_size; }
 
 		/**@brief Returns the amount of items in the sparse_map.
 		 * @returns size_type Current amount of items contained in sparse_map.
@@ -88,7 +88,7 @@ namespace args::core
 		{
 			if (size > m_capacity)
 			{
-				m_dense_value.resize(size);
+		m_dense_value.resize(size);
 				m_dense_key.resize(size);
 				m_capacity = size;
 			}


### PR DESCRIPTION
added qualifier 'mutable' to `atomic_sparse_map::m_container_lock`
renamed residual `sparse_map::m_dense` references to `sparse_map::m_dense_value`

fix #42 