### PR TITLE
added tools/cppcheck2github.py

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -33,4 +33,4 @@ jobs:
        /home/runner/.local/bin/analyze-build --status-bugs
 
     - name: cppcheck
-      run: cd args && cppcheck --project=args.sln --error-exitcode=1 
+      run: cd args && cppcheck --project=args.sln --xml --error-exitcode=1 2>&1 | python3 ../tools/cppcheck2github.py

--- a/tools/cppcheck2github.py
+++ b/tools/cppcheck2github.py
@@ -21,10 +21,13 @@ class github_log:
         self.message = ''
 
     def generate(self):
-        if(self.type != ''):
+        if self.type != '':
             print(f'::{self.type} file={self.file},line={self.line},col={self.col}::{self.message}')
-            global return_code
+            return 1
+        else:
+            return 0
 
+return_code = 0
 
 report = ET.fromstring(output)
 for error in report[1]:
@@ -46,4 +49,8 @@ for error in report[1]:
             log.line = '0'
             log.file = '[internal]'
 
-        log.generate()
+        code = log.generate()
+        if return_code == 0:
+            return_code = code
+
+sys.exit(return_code)

--- a/tools/cppcheck2github.py
+++ b/tools/cppcheck2github.py
@@ -1,0 +1,49 @@
+import sys
+import xml.etree.ElementTree as ET
+from pprint import pprint
+
+output = ''
+
+try:
+    for line in sys.stdin:
+        output += line
+except KeyboardInterrupt:
+    sys.stdout.flush()
+    pass
+
+
+class github_log:
+    def __init__(self):
+        self.type = ''
+        self.file = ''
+        self.line = ''
+        self.col = ''
+        self.message = ''
+
+    def generate(self):
+        if(self.type != ''):
+            print(f'::{self.type} file={self.file},line={self.line},col={self.col}::{self.message}')
+            global return_code
+
+
+report = ET.fromstring(output)
+for error in report[1]:
+    if error.tag == 'error':
+
+        #generate new github log and populate with default values
+        log = github_log();
+        log.type = error.attrib.get('severity','warning')
+        log.message = error.attrib.get('msg','unknown')
+
+        if len(list(error)) > 0:
+            if error[0].tag == 'location':
+                log.line = error[0].attrib.get('line','0')
+                log.col  = error[0].attrib.get('column','0')
+                log.file = error[0].attrib.get('file','[internal]')
+
+        else:
+            log.col = '0'
+            log.line = '0'
+            log.file = '[internal]'
+
+        log.generate()


### PR DESCRIPTION
added a custom tool to reformat cppcheck errors as github messages:
https://github.com/Algo-ryth-mix/cppcheck-github
Formats errors like this
![grafik](https://user-images.githubusercontent.com/12379720/90114076-819f9f00-dd52-11ea-9138-c398a144bb43.png)
instead of this 
![grafik](https://user-images.githubusercontent.com/12379720/90114118-90865180-dd52-11ea-8e8f-a73b9b4400c3.png)

Note that this also changes the return type to always be 0, if wanted we can change this back in the script