### PR TITLE
excluded ../application from the doxygen sources

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../args ../applications
+INPUT                  = ../args
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Excluded `../applications` from the Doxygen Source in `docs/Doxyfile` to avoid having build issues with 
unnecessary projects