### PR TITLE
Feature/audio

### DIFF
--- a/applications/sandbox/assets/audio/kilogram-of-scotland.wav
+++ b/applications/sandbox/assets/audio/kilogram-of-scotland.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a45fa0b5714a8eacb87b75dbf123a0207c1513a4b599807a69a5eaf513ca3f47
+size 22579244

--- a/applications/sandbox/systems/testsystem.hpp
+++ b/applications/sandbox/systems/testsystem.hpp
@@ -344,7 +344,7 @@ public:
             sphere.add_components<rendering::renderable, sah>({ uvsphereH, wireframeH }, {});
             sphere.add_components<transform>(position(-5.1f, 3, 0), rotation(), scale(2.5f));
 
-            auto segment = audio::AudioSegmentCache::createAudioSegment("kilogram", "assets://audio/kilogram-of-scotland_mono.mp3"_view);
+            auto segment = audio::AudioSegmentCache::createAudioSegment("kilogram", "assets://audio/kilogram-of-scotland.wav"_view);
             if (segment)
             {
                 audio::audio_source source;

--- a/legion/engine/audio/components/audio_source.hpp
+++ b/legion/engine/audio/components/audio_source.hpp
@@ -137,6 +137,26 @@ namespace legion::audio
             return m_audio_handle;
         }
 
+        int getChannels()
+        {
+            int channels = 0;
+            {
+                async::readonly_guard guard(m_audio_handle.get().first);
+                channels = m_audio_handle.get().second.channels;
+            }
+            return channels;
+        }
+
+        bool isStereo()
+        {
+            return getChannels() == 2;
+        }
+
+        bool isMono()
+        {
+            return getChannels() == 1;
+        }
+
     private:
         /**
         * @brief Function to clear the changes that will be applied
@@ -163,7 +183,6 @@ namespace legion::audio
         // b1 - gain
         // b2 - play state
         // b3 - rewind (doRewind)
-
         byte m_changes = 0;
     };
 }

--- a/legion/engine/audio/data/audio_segment.cpp
+++ b/legion/engine/audio/data/audio_segment.cpp
@@ -7,7 +7,7 @@ namespace legion::audio
     std::mutex audio_segment::m_refsLock;
     id_type audio_segment::m_lastId = 1;
 
-    audio_segment::audio_segment(int16* data, ALuint bufferId, size_type samples, int channels, int sampleRate, int layer, int avg_bitRate) :
+    audio_segment::audio_segment(byte* data, ALuint bufferId, size_type samples, int channels, int sampleRate, int layer, int avg_bitRate) :
         audioBufferId(bufferId), samples(samples), channels(channels), sampleRate(sampleRate), layer(layer), avg_bitrate_kbps(avg_bitRate)
     {
         std::lock_guard guard(m_refsLock);

--- a/legion/engine/audio/data/audio_segment.hpp
+++ b/legion/engine/audio/data/audio_segment.hpp
@@ -18,7 +18,7 @@ namespace legion::audio
 
         audio_segment() = default;
 
-        audio_segment(int16* data, ALuint bufferId, size_type samples, int channels, int sampleRate, int layer, int avg_bitRate);
+        audio_segment(byte* data, ALuint bufferId, size_type samples, int channels, int sampleRate, int layer, int avg_bitRate);
 
         audio_segment(const audio_segment& other);
 
@@ -31,13 +31,13 @@ namespace legion::audio
         ~audio_segment();
 
         // Read-Write
-        int16* getData()
+        byte* getData()
         {
             return m_data;
         }
 
         // Read only
-        const int16* getData() const
+        const byte* getData() const
         {
             return m_data;
         }
@@ -47,7 +47,7 @@ namespace legion::audio
         static std::mutex m_refsLock;
         static id_type m_lastId;
         id_type m_id;
-        int16* m_data;
+        byte* m_data;
 	};
 
     struct audio_import_settings

--- a/legion/engine/audio/data/importers/audio_importers.cpp
+++ b/legion/engine/audio/data/importers/audio_importers.cpp
@@ -8,8 +8,6 @@
 
 namespace legion::audio
 {
-    ALCcontext* mp3_audio_loader::context = nullptr;
-
     common::result_decay_more<audio_segment, fs_error> mp3_audio_loader::load(const fs::basic_resource& resource, audio_import_settings&& settings)
     {
         using common::Err, common::Ok;
@@ -28,7 +26,7 @@ namespace legion::audio
         }
 
         audio_segment as(
-            new int16[fileInfo.samples],
+            new byte[fileInfo.samples * 2], // fileInfo.samples is int16, therefore byte requires twice as much
             0,
             fileInfo.samples,
             fileInfo.channels,
@@ -40,12 +38,97 @@ namespace legion::audio
         free(fileInfo.buffer);
 
         async::readwrite_guard guard(AudioSystem::contextLock);
-        alcMakeContextCurrent(context);
+        alcMakeContextCurrent(AudioSystem::alcContext);
         //Generate openal buffer
         alGenBuffers((ALuint)1, &as.audioBufferId);
-        ALuint format = AL_FORMAT_MONO16;
+        ALenum format = AL_FORMAT_MONO16;
         if (as.channels == 2) format = AL_FORMAT_STEREO16;
         alBufferData(as.audioBufferId, format, as.getData(), as.samples * sizeof(int16), as.sampleRate);
+
+        alcMakeContextCurrent(nullptr);
+
+        return decay(Ok(as));
+    }
+
+    common::result_decay_more<audio_segment, fs_error> wav_audio_loader::load(const fs::basic_resource& resource, audio_import_settings&& settings)
+    {
+        using common::Err, common::Ok;
+        using decay = common::result_decay_more<audio_segment, fs_error>;
+
+        RIFF_Header header;
+        WAVE_Data waveData;
+
+        memcpy(&header, resource.data() , sizeof(header)); // Copy header data into the header struct
+
+        // Check if the loaded file has the correct header
+
+        if (header.chunckId[0] != 'R' ||
+            header.chunckId[1] != 'I' ||
+            header.chunckId[2] != 'F' ||
+            header.chunckId[3] != 'F')
+        {
+            return decay(Err(legion_fs_error("WAV File invalid header, exptected RIFF")));
+        }
+
+        if (header.format[0] != 'W' ||
+            header.format[1] != 'A' ||
+            header.format[2] != 'V' ||
+            header.format[3] != 'E')
+        {
+            return decay(Err(legion_fs_error("Loaded File is not of type WAV")));
+        }
+
+        if (header.wave_format.subChunckId[0] != 'f' ||
+            header.wave_format.subChunckId[1] != 'm' ||
+            header.wave_format.subChunckId[2] != 't' ||
+            header.wave_format.subChunckId[3] != ' ')
+        {
+            return decay(Err(legion_fs_error("WAV File sub chunck id was not (fmt )")));
+        }
+
+        memcpy(&waveData, resource.data() + sizeof(header), sizeof(waveData));
+        if (waveData.subChunckId[0] != 'd' ||
+            waveData.subChunckId[1] != 'a' ||
+            waveData.subChunckId[2] != 't' ||
+            waveData.subChunckId[3] != 'a')
+        {
+            return decay(Err(legion_fs_error("WAV File sample data does not start with word (data)")));
+        }
+
+        const unsigned long sampleDataSize = resource.size() - sizeof(header) - sizeof(waveData);
+        byte* audioData = new byte[sampleDataSize];
+        memcpy(audioData, resource.data() + sizeof(header) + sizeof(waveData), sampleDataSize);
+        
+        audio_segment as(
+            new byte[sampleDataSize],
+            0,
+            -1, // Sample count, unknown for wav
+            header.wave_format.channels,
+            (int)header.wave_format.sampleRate,
+            -1, // Layer, does not exist in wav
+            -1 // avg_biterate_kbps, unknown for wav
+        );
+        memmove(as.getData(), audioData, sampleDataSize);
+        delete[] audioData; // Data has been moved, thus old data can be deleted
+
+        async::readwrite_guard guard(AudioSystem::contextLock);
+        alcMakeContextCurrent(AudioSystem::alcContext);
+        //Generate openal buffer
+        alGenBuffers((ALuint)1, &as.audioBufferId);
+        ALenum format = AL_FORMAT_MONO16;
+        if (as.channels == 1)
+        {
+            if (header.wave_format.bitsPerSample == 8) format = AL_FORMAT_MONO8;
+            if (header.wave_format.bitsPerSample == 16) format = AL_FORMAT_MONO16;
+            if (header.wave_format.bitsPerSample == 32) format = AL_FORMAT_MONO_FLOAT32;
+        }
+        else if (as.channels == 2)
+        {
+            if (header.wave_format.bitsPerSample == 8) format = AL_FORMAT_STEREO8;
+            if (header.wave_format.bitsPerSample == 16) format = AL_FORMAT_STEREO16;
+            if (header.wave_format.bitsPerSample == 32) format = AL_FORMAT_STEREO_FLOAT32;
+        }
+        alBufferData(as.audioBufferId, format, as.getData(), sampleDataSize, as.sampleRate);
 
         alcMakeContextCurrent(nullptr);
 

--- a/legion/engine/audio/data/importers/audio_importers.cpp
+++ b/legion/engine/audio/data/importers/audio_importers.cpp
@@ -43,7 +43,10 @@ namespace legion::audio
         alcMakeContextCurrent(context);
         //Generate openal buffer
         alGenBuffers((ALuint)1, &as.audioBufferId);
-        alBufferData(as.audioBufferId, AL_FORMAT_MONO16, as.getData(), as.samples * sizeof(int16), as.sampleRate);
+        ALuint format = AL_FORMAT_MONO16;
+        if (as.channels == 2) format = AL_FORMAT_STEREO16;
+        alBufferData(as.audioBufferId, format, as.getData(), as.samples * sizeof(int16), as.sampleRate);
+
         alcMakeContextCurrent(nullptr);
 
         return decay(Ok(as));

--- a/legion/engine/audio/data/importers/audio_importers.hpp
+++ b/legion/engine/audio/data/importers/audio_importers.hpp
@@ -7,6 +7,34 @@ namespace legion::audio
     struct mp3_audio_loader : public fs::resource_converter<audio_segment, audio_import_settings>
     {
         virtual common::result_decay_more<audio_segment, fs_error> load(const fs::basic_resource& resource, audio_import_settings&& settings) override;
-        static ALCcontext* context;
+    };
+
+    struct wav_audio_loader : public fs::resource_converter<audio_segment, audio_import_settings>
+    {
+        virtual common::result_decay_more<audio_segment, fs_error> load(const fs::basic_resource& resource, audio_import_settings&& settings) override;
+
+        struct RIFF_Header // 36 Bytes of data for WAV header
+        {
+            uint8 chunckId[4]; // Contains the chars "RIFF"
+            int32 chunckSize;
+            uint8 format[4]; // Contains the chars "WAVE"
+            struct WAVE_Format
+            {
+                uint8 subChunckId[4]; // Contains the chars "fmt "
+                int32 subchunckSize;
+                int16 audioFormat;
+                int16 channels; // Stereo or mono
+                int32 sampleRate; // Sample rate / frequency
+                int32 byteRate;
+                int16 blockAlign;
+                int16 bitsPerSample; // Audio resolution
+            } wave_format;
+        };
+
+        struct WAVE_Data
+        {
+            uint8 subChunckId[4]; // Contains the chars "data"
+            int32 subChunck2Size; // Sample data
+        };
     };
 }

--- a/legion/engine/audio/module/audiomodule.hpp
+++ b/legion/engine/audio/module/audiomodule.hpp
@@ -15,6 +15,7 @@ namespace legion::audio
             addProcessChain("Audio");
 
             fs::AssetImporter::reportConverter<mp3_audio_loader>(".mp3");
+            fs::AssetImporter::reportConverter<wav_audio_loader>(".wav");
 
             reportComponentType<audio_source>();
             reportComponentType<audio_listener>();

--- a/legion/engine/audio/systems/audiosystem.inl
+++ b/legion/engine/audio/systems/audiosystem.inl
@@ -58,7 +58,6 @@ namespace legion::audio
 
 		// Release context on this thread
 		alcMakeContextCurrent(nullptr);
-		mp3_audio_loader::context = alcContext;
 	}
 
 	inline void AudioSystem::onEngineExit(events::exit* event)


### PR DESCRIPTION
ADD:
+ WAV file loading
+ File: kilogram-of-scotland.wav
+ Mono and stereo files can be loaded (mp3 and WAV) and are handled correctly
+ 8, 16 and 32-float bit audio can be loaded (WAV) and handled correctly 