### PR TITLE
Allow for other repositories to make docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,7 @@ jobs:
       uses: appleboy/ssh-action@master
       with:
         script: |
-         rm -rf ~/public_html/docs
+         find ~/public_html/docs ! -type l -delete || true
          mkdir docs || true
          #creating the folder will fail if it already exists, but we do not care about that
         host: ${{ secrets.DOCS_HOST }}


### PR DESCRIPTION
Currently the docs action would completely purge the remote server when it rebuilds, this is nice for a sane docs environment, but a little bit bad if other projects also want to write to that directory, this pr replaces the hard purge `rm -rf ~\public_html\docs` with an approach that preserves symlinks `find ~\public_html\docs ! -type l -delete`