### PR TITLE
Task/build applications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ set(RYTHE_ENABLED_MODULE_PATHS "")
 add_subdirectory(${RYTHE_DIR_RYTHE})
 
 # The engine is ready - add applications
-foreach(path ${RYTHE_ENABLED_MODULE_PATHS})
-	add_subdirectory(${RYTHE_DIR_ROOT}/${path}/applications)
-endforeach()
+if (${RYTHE_BUILD_APPLICATIONS})
+	foreach(path ${RYTHE_ENABLED_MODULE_PATHS})
+		add_subdirectory(${RYTHE_DIR_ROOT}/${path}/applications)
+	endforeach()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,14 +86,18 @@ mark_as_advanced(FORCE BUILD_SHARED_LIBS) # Hide
 # Utility files
 include("${CMAKE_MODULE_PATH}/update_submodule.cmake")
 include("${CMAKE_MODULE_PATH}/copy_module_output.cmake")
+include("${CMAKE_MODULE_PATH}/configure_application.cmake")
+include("${CMAKE_MODULE_PATH}/configure_module.cmake")
 
 # Get Git
 find_package(Git REQUIRED)
 
 # Add Rythe
+set(RYTHE_ENABLED_MODULE_NAMES "")
+set(RYTHE_ENABLED_MODULE_PATHS "")
 add_subdirectory(${RYTHE_DIR_RYTHE})
 
 # The engine is ready - add applications
-if (${RYTHE_BUILD_APPLICATIONS})
-    #add_subdirectory(${RYTHE_DIR_ROOT}/applications)
-endif()
+foreach(path ${RYTHE_ENABLED_MODULE_PATHS})
+	add_subdirectory(${RYTHE_DIR_ROOT}/${path}/applications)
+endforeach()

--- a/applications/todo.txt
+++ b/applications/todo.txt
@@ -1,1 +1,0 @@
-Write CMake script that gathers all applications from modules

--- a/cmake/configure_application.cmake
+++ b/cmake/configure_application.cmake
@@ -15,9 +15,9 @@ function(configure_engine_application target)
 	
 	# Linker
 	if (NOT ${RYTHE_LINKER_FLAGS} STREQUAL "")
-		target_link_options(${library} PUBLIC ${RYTHE_LINKER_FLAGS})
+		target_link_options(${target} PUBLIC ${RYTHE_LINKER_FLAGS})
 	endif()
-	set_target_properties(${library} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
+	set_target_properties(${target} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
 endfunction()
 	
 function(configure_editor_application target)
@@ -34,7 +34,7 @@ function(configure_editor_application target)
 	
 	# Linker
 	if (NOT ${RYTHE_LINKER_FLAGS} STREQUAL "")
-		target_link_options(${library} PUBLIC ${RYTHE_LINKER_FLAGS})
+		target_link_options(${target} PUBLIC ${RYTHE_LINKER_FLAGS})
 	endif()
-	set_target_properties(${library} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
+	set_target_properties(${target} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
 endfunction()

--- a/cmake/configure_application.cmake
+++ b/cmake/configure_application.cmake
@@ -1,0 +1,40 @@
+# Utility file that introduces configure_engine_application() and configure_editor_application()
+# These functions simplify setting up compiler settings and dependencies.
+
+function(configure_engine_application target)
+	# Language
+	target_compile_features(${target} PUBLIC cxx_std_17)
+	
+	# Dependency on Rythe
+	target_include_directories(${target} PUBLIC ${RYTHE_INCLUDE_ENGINE})
+	target_link_libraries(${target} PUBLIC ${RYTHE_LIBS_ENGINE})
+	
+	# Compiler
+	target_compile_definitions(${target} PUBLIC ${RYTHE_DEFINITIONS})
+	target_compile_options(${target} PUBLIC ${RYTHE_COMPILER_FLAGS})
+	
+	# Linker
+	if (NOT ${RYTHE_LINKER_FLAGS} STREQUAL "")
+		target_link_options(${library} PUBLIC ${RYTHE_LINKER_FLAGS})
+	endif()
+	set_target_properties(${library} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
+endfunction()
+	
+function(configure_editor_application target)
+	# Language
+	target_compile_features(${target} PUBLIC cxx_std_17)
+	
+	# Dependency on Rythe
+	target_include_directories(${target} PUBLIC ${RYTHE_INCLUDE_ALL})
+	target_link_libraries(${target} PUBLIC ${RYTHE_LIBS_ALL})
+	
+	# Compiler
+	target_compile_definitions(${target} PUBLIC ${RYTHE_DEFINITIONS})
+	target_compile_options(${target} PUBLIC ${RYTHE_COMPILER_FLAGS})
+	
+	# Linker
+	if (NOT ${RYTHE_LINKER_FLAGS} STREQUAL "")
+		target_link_options(${library} PUBLIC ${RYTHE_LINKER_FLAGS})
+	endif()
+	set_target_properties(${library} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
+endfunction()

--- a/cmake/configure_application.cmake
+++ b/cmake/configure_application.cmake
@@ -1,7 +1,7 @@
-# Utility file that introduces configure_engine_application() and configure_editor_application()
+# Utility file that introduces rythe_configure_engine_application() and rythe_configure_editor_application()
 # These functions simplify setting up compiler settings and dependencies.
 
-function(configure_engine_application target)
+function(rythe_configure_engine_application target)
 	# Language
 	target_compile_features(${target} PUBLIC cxx_std_17)
 	
@@ -20,7 +20,7 @@ function(configure_engine_application target)
 	set_target_properties(${target} PROPERTIES LINKER_LANGUAGE ${RYTHE_LANGUAGE})
 endfunction()
 	
-function(configure_editor_application target)
+function(rythe_configure_editor_application target)
 	# Language
 	target_compile_features(${target} PUBLIC cxx_std_17)
 	

--- a/cmake/configure_module.cmake
+++ b/cmake/configure_module.cmake
@@ -1,0 +1,26 @@
+# Utility file that introduces a configure_module macro.
+# Unlike configure_application.cmake, this is intentionally introduced as a macro so that
+# the functions called internally can use the true parent scope appropriately.
+
+macro(configure_module module)
+    set(MODULE_INFO_HAS_HEADERS OFF PARENT_SCOPE)
+    set(MODULE_INFO_HAS_SOURCES OFF PARENT_SCOPE)
+
+    get_target_property(MODULE_SOURCES ${module} SOURCES)
+    set(MODULE_INFO_SOURCES ${MODULE_SOURCES} PARENT_SCOPE)
+
+    foreach(src ${MODULE_SOURCES})
+        get_filename_component(SRC_EXT ${src} EXT)
+
+        if (SRC_EXT STREQUAL ".hpp" OR 
+            SRC_EXT STREQUAL ".h" OR 
+            SRC_EXT STREQUAL ".inl")
+            set(MODULE_INFO_HAS_HEADERS ON PARENT_SCOPE)
+        endif()
+
+        if (SRC_EXT STREQUAL ".cpp" OR 
+            SRC_EXT STREQUAL ".c")
+            set(MODULE_INFO_HAS_SOURCES ON PARENT_SCOPE)
+        endif()
+    endforeach()
+endmacro()

--- a/cmake/configure_module.cmake
+++ b/cmake/configure_module.cmake
@@ -1,8 +1,8 @@
-# Utility file that introduces a configure_module macro.
+# Utility file that introduces a rythe_configure_module macro.
 # Unlike configure_application.cmake, this is intentionally introduced as a macro so that
 # the functions called internally can use the true parent scope appropriately.
 
-macro(configure_module module)
+macro(rythe_configure_module module)
     set(MODULE_INFO_HAS_HEADERS OFF PARENT_SCOPE)
     set(MODULE_INFO_HAS_SOURCES OFF PARENT_SCOPE)
 

--- a/cmake/copy_module_output.cmake
+++ b/cmake/copy_module_output.cmake
@@ -19,24 +19,26 @@ function(copy_module_output targetName targetDir)
 		make_directory ${RYTHE_DIR_OUTPUT_LIBS}/Release
 	)
 
-	# Copy debug library
-	# Note: || (exit 0) makes sure these commands succeed even if no library file was generated.
-	add_custom_command(TARGET ${targetName} 
-		POST_BUILD
-		COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> -E 
-		copy 
-			$<TARGET_FILE:${targetName}>
-			"${RYTHE_DIR_OUTPUT_LIBS}/Debug/" || (exit 0)
-	)
+	if (${MODULE_INFO_HAS_SOURCES})
+		# Copy debug library
+		# Note: || (exit 0) makes sure these commands succeed even if no library file was generated.
+		add_custom_command(TARGET ${targetName} 
+			POST_BUILD
+			COMMAND $<$<CONFIG:Debug>:${CMAKE_COMMAND}> -E 
+			copy 
+				$<TARGET_FILE:${targetName}>
+				"${RYTHE_DIR_OUTPUT_LIBS}/Debug/" || (exit 0)
+		)
 
-	# Copy release library
-	add_custom_command(TARGET ${targetName} 
-		POST_BUILD
-		COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> -E 
-		copy
-			$<TARGET_FILE:${targetName}>
-			"${RYTHE_DIR_OUTPUT_LIBS}/Release/" || (exit 0)
-	)
+		# Copy release library
+		add_custom_command(TARGET ${targetName} 
+			POST_BUILD
+			COMMAND $<$<CONFIG:Release>:${CMAKE_COMMAND}> -E 
+			copy
+				$<TARGET_FILE:${targetName}>
+				"${RYTHE_DIR_OUTPUT_LIBS}/Release/" || (exit 0)
+		)
+	endif()
 	
 	# Macro for recursively going through directories.
 	# This is necessary because cmake copy takes a directory,

--- a/cmake/copy_module_output.cmake
+++ b/cmake/copy_module_output.cmake
@@ -5,7 +5,7 @@
 # it uses ${RYTHE_DIR_ROOT} to get full filepaths and ${RYTHE_DIR_OUTPUT_INCLUDES} to copy results to.
 
 # Add post-build commands to copy library and header files to output directories.
-function(copy_module_output targetName targetDir)
+function(rythe_copy_module_output targetName targetDir)
 	# Prepare directories for library output
 	add_custom_command(TARGET ${targetName} 
 		POST_BUILD

--- a/cmake/update_submodule.cmake
+++ b/cmake/update_submodule.cmake
@@ -1,7 +1,7 @@
 # Utility function for updating a git submodule.
 # Simply calls `git submodule update --init --recursive --rebase -- ${modulePath}`,
 # but only if the submodule hasn't already been updated (checks for common repo files).
-function(update_submodule modulePath)
+function(rythe_update_submodule modulePath)
 	if( NOT (EXISTS ${RYTHE_DIR_ROOT}/${modulePath}/README.md) AND
 		NOT (EXISTS ${RYTHE_DIR_ROOT}/${modulePath}/.gitignore) AND 
 		NOT (EXISTS ${RYTHE_DIR_ROOT}/${modulePath}/CMakeLists.txt))

--- a/rythe/CMakeLists.txt
+++ b/rythe/CMakeLists.txt
@@ -48,7 +48,7 @@ if (NOT ${SUBMODULE_COUNT} EQUAL 0)
             set(MODULE_INFO_HAS_SOURCES OFF)
             set(MODULE_INFO_SOURCES "")
 
-            update_submodule(${SUBMODULE_PATH})
+            rythe_update_submodule(${SUBMODULE_PATH})
             add_subdirectory(${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src/${SUBMODULE_NAME})
             set_target_properties(${SUBMODULE_NAME} PROPERTIES FOLDER ${SUBMODULE_DIR})
 
@@ -81,7 +81,7 @@ if (NOT ${SUBMODULE_COUNT} EQUAL 0)
                 list(GET SUBMODULE_HASHES ${SUBMODULE_EDITOR_INDEX} SUBMODULE_EDITOR_HASH)
 
                 message(STATUS "Editor: ${SUBMODULE_EDITOR_NAME} found!")
-                update_submodule("${SUBMODULE_EDITOR_PATH}")
+                rythe_update_submodule("${SUBMODULE_EDITOR_PATH}")
                 add_subdirectory("${SUBMODULE_EDITOR_PATH}/src/${SUBMODULE_NAME}-editor")
                 set_target_properties("${SUBMODULE_NAME}-editor" PROPERTIES FOLDER ${SUBMODULE_EDITOR_DIR})
 

--- a/rythe/CMakeLists.txt
+++ b/rythe/CMakeLists.txt
@@ -42,16 +42,34 @@ if (NOT ${SUBMODULE_COUNT} EQUAL 0)
             (${RYTHE_FORCE_ENABLE_ALL_MODULES}))
 
             message(STATUS "Module: ${SUBMODULE_NAME} [Enabled]")
+            # MODULE_INFO variables are updated by the module
+            # see cmake/configure_module.cmake
+            set(MODULE_INFO_HAS_HEADERS OFF)
+            set(MODULE_INFO_HAS_SOURCES OFF)
+            set(MODULE_INFO_SOURCES "")
+
             update_submodule(${SUBMODULE_PATH})
             add_subdirectory(${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src/${SUBMODULE_NAME})
             set_target_properties(${SUBMODULE_NAME} PROPERTIES FOLDER ${SUBMODULE_DIR})
 
-            # Add the submodule to the link list
-            list(APPEND RYTHE_LIBS_ALL ${SUBMODULE_NAME})
-            list(APPEND RYTHE_LIBS_ENGINE ${SUBMODULE_NAME})
-            list(APPEND RYTHE_INCLUDE_ALL "${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src")
-            list(APPEND RYTHE_INCLUDE_ENGINE "${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src")
+            # No need to add as an include path if no headers are present
+            if (${MODULE_INFO_HAS_HEADERS})
+                list(APPEND RYTHE_INCLUDE_ALL "${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src")
+                list(APPEND RYTHE_INCLUDE_ENGINE "${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src")
+            endif()
+
+            # We have to check explicitly because otherwise
+            # targets will attempt to link with ${SUBMODULE_NAME}, which won't
+            # exist if the target has no cpp or c files
+            if (${MODULE_INFO_HAS_SOURCES})
+                list(APPEND RYTHE_LIBS_ALL ${SUBMODULE_NAME})
+                list(APPEND RYTHE_LIBS_ENGINE ${SUBMODULE_NAME})
+            endif()
+            
             list(APPEND RYTHE_DEFINITIONS "RYTHE_${SUBMODULE_VARIABLE_NAME}")
+
+            list(APPEND RYTHE_ENABLED_MODULE_NAMES ${SUBMODULE_NAME})
+            list(APPEND RYTHE_ENABLED_MODULE_PATHS ${SUBMODULE_PATH})
 
             # Try to find a matching editor
             list(FIND SUBMODULE_PATHS "rythe/editor/modules/${SUBMODULE_NAME}" SUBMODULE_EDITOR_INDEX)
@@ -100,3 +118,14 @@ foreach(library ${RYTHE_LIBS_EDITOR})
     target_compile_features(${library} PUBLIC cxx_std_17)
     target_link_options(${library} PUBLIC ${RYTHE_LINKER_FLAGS})
 endforeach()
+
+# Re-set all the modified RYTHE variables but with PARENT_SCOPE enabled
+# so that it properly updates in the root scope.
+set(RYTHE_LIBS_ALL ${RYTHE_LIBS_ALL} PARENT_SCOPE)
+set(RYTHE_LIBS_ENGINE ${RYTHE_LIBS_ENGINE} PARENT_SCOPE)
+set(RYTHE_INCLUDE_ALL ${RYTHE_INCLUDE_ALL} PARENT_SCOPE)
+set(RYTHE_INCLUDE_ENGINE ${RYTHE_INCLUDE_ENGINE} PARENT_SCOPE)
+set(RYTHE_DEFINITIONS ${RYTHE_DEFINITIONS} PARENT_SCOPE)
+
+set(RYTHE_ENABLED_MODULE_NAMES ${RYTHE_ENABLED_MODULE_NAMES} PARENT_SCOPE)
+set(RYTHE_ENABLED_MODULE_PATHS ${RYTHE_ENABLED_MODULE_PATHS} PARENT_SCOPE)


### PR DESCRIPTION
Automatically adds in applications from modules when the modules are enabled.

This PR also fixes an issue where submodules were added to the linker even if they didn't have c or cpp files (and thus wouldn't generate a static library)