### PR TITLE
Task/handle submodule deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ CMakeScripts/
 cmake_install.cmake
 CMakeCache.txt
 cmake-build-*/
+CMakeDoxyfile.in
+CMakeDoxygenDefaults.cmake
 
 # CMake Tests
 CTestTestfile.cmake
@@ -71,6 +73,7 @@ x86/
 *.vcxproj
 *.vcxproj.user
 *.vcxproj.filters
+.vs/
 
 # Visual Studio Code
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ include("${CMAKE_MODULE_PATH}/copy_module_output.cmake")
 include("${CMAKE_MODULE_PATH}/configure_application.cmake")
 include("${CMAKE_MODULE_PATH}/configure_module.cmake")
 include("${CMAKE_MODULE_PATH}/add_third_party.cmake")
+include("${CMAKE_MODULE_PATH}/find_sources.cmake")
 
 # Get Git
 find_package(Git REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,13 @@ set(RYTHE_FILE_TYPES *.h *.hpp *.c *.cpp *.inl)
 set(RYTHE_INCLUDE_ALL "")
 set(RYTHE_INCLUDE_ENGINE "")
 set(RYTHE_INCLUDE_EDITOR "")
+set(RYTHE_INCLUDE_THIRD_PARTY "")
 
 # Libs
 set(RYTHE_LIBS_ALL "")
 set(RYTHE_LIBS_ENGINE "")
 set(RYTHE_LIBS_EDITOR "")
+set(RYTHE_LIBS_THIRD_PARTY "")
 
 # Definitions
 set(RYTHE_DEFINITIONS "")
@@ -88,6 +90,7 @@ include("${CMAKE_MODULE_PATH}/update_submodule.cmake")
 include("${CMAKE_MODULE_PATH}/copy_module_output.cmake")
 include("${CMAKE_MODULE_PATH}/configure_application.cmake")
 include("${CMAKE_MODULE_PATH}/configure_module.cmake")
+include("${CMAKE_MODULE_PATH}/add_third_party.cmake")
 
 # Get Git
 find_package(Git REQUIRED)

--- a/cmake/add_dependency.cmake
+++ b/cmake/add_dependency.cmake
@@ -1,0 +1,6 @@
+# Simple dependency macro that checks if the dependency has previously been added before adding it
+macro(rythe_add_dependency name dir)
+    if (NOT TARGET ${name})
+        add_subdirectory(dir)
+    endif()
+macro()

--- a/cmake/add_dependency.cmake
+++ b/cmake/add_dependency.cmake
@@ -1,6 +1,0 @@
-# Simple dependency macro that checks if the dependency has previously been added before adding it
-macro(rythe_add_dependency name dir)
-    if (NOT TARGET ${name})
-        add_subdirectory(dir)
-    endif()
-macro()

--- a/cmake/add_third_party.cmake
+++ b/cmake/add_third_party.cmake
@@ -1,0 +1,27 @@
+# Simple macro that checks if the third party library has previously been added before adding it
+macro(rythe_add_third_party)
+	set(options CURRENT_HEADER_ONLY LIBRARY_HEADER_ONLY)
+	set(oneValueArgs CURRENT LIBRARY PATH INCLUDE FOLDER)
+	set(multiValueArgs FOLDER_TARGETS)
+	cmake_parse_arguments(RYTHE_ADD_THIRD_PARTY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+	message(STATUS ${RYTHE_ADD_THIRD_PARTY_PATH}})
+
+    if (NOT TARGET ${RYTHE_ADD_THIRD_PARTY_LIBRARY})
+        add_subdirectory(${RYTHE_ADD_THIRD_PARTY_PATH})
+
+		foreach(target ${RYTHE_ADD_THIRD_PARTY_FOLDER_TARGETS})
+			set_target_properties(${target} PROPERTIES FOLDER ${RYTHE_ADD_THIRD_PARTY_FOLDER})
+		endforeach()
+
+		set(RYTHE_INCLUDE_THIRD_PARTY ${RYTHE_INCLUDE_THIRD_PARTY} ${RYTHE_ADD_THIRD_PARTY_INCLUDE} PARENT_SCOPE)
+
+		if (NOT ${RYTHE_ADD_THIRD_PARTY_LIBRARY_HEADER_ONLY})
+			set(RYTHE_LIBS_THIRD_PARTY ${RYTHE_LIBS_THIRD_PARTY} ${RYTHE_ADD_THIRD_PARTY_LIBRARY} PARENT_SCOPE)
+		endif()
+    endif()
+
+	if (NOT ${RYTHE_ADD_THIRD_PARTY_CURRENT_HEADER_ONLY})
+		target_include_directories(${RYTHE_ADD_THIRD_PARTY_CURRENT} PUBLIC ${RYTHE_ADD_THIRD_PARTY_INCLUDE})
+	endif()
+endmacro()

--- a/cmake/configure_application.cmake
+++ b/cmake/configure_application.cmake
@@ -8,6 +8,9 @@ function(rythe_configure_engine_application target)
 	# Dependency on Rythe
 	target_include_directories(${target} PUBLIC ${RYTHE_INCLUDE_ENGINE})
 	target_link_libraries(${target} PUBLIC ${RYTHE_LIBS_ENGINE})
+
+	target_include_directories(${target} PUBLIC ${RYTHE_INCLUDE_THIRD_PARTY})
+	target_link_libraries(${target} PUBLIC ${RYTHE_LIBS_THIRD_PARTY})
 	
 	# Compiler
 	target_compile_definitions(${target} PUBLIC ${RYTHE_DEFINITIONS})
@@ -27,6 +30,9 @@ function(rythe_configure_editor_application target)
 	# Dependency on Rythe
 	target_include_directories(${target} PUBLIC ${RYTHE_INCLUDE_ALL})
 	target_link_libraries(${target} PUBLIC ${RYTHE_LIBS_ALL})
+		
+	target_include_directories(${target} PUBLIC ${RYTHE_INCLUDE_THIRD_PARTY})
+	target_link_libraries(${target} PUBLIC ${RYTHE_LIBS_THIRD_PARTY})
 	
 	# Compiler
 	target_compile_definitions(${target} PUBLIC ${RYTHE_DEFINITIONS})

--- a/cmake/find_sources.cmake
+++ b/cmake/find_sources.cmake
@@ -1,0 +1,6 @@
+# Utility macro to find files in directory and store into the given parameter
+
+macro(rythe_find_sources sources directory)
+	file(GLOB_RECURSE sources ${RYTHE_FILE_TYPES})
+	list(FILTER sources INCLUDE REGEX ${directory})
+endmacro()

--- a/rythe/CMakeLists.txt
+++ b/rythe/CMakeLists.txt
@@ -49,7 +49,7 @@ if (NOT ${SUBMODULE_COUNT} EQUAL 0)
             set(MODULE_INFO_SOURCES "")
 
             rythe_update_submodule(${SUBMODULE_PATH})
-            add_subdirectory(${RYTHE_DIR_ROOT}/${SUBMODULE_PATH}/src/${SUBMODULE_NAME})
+            add_subdirectory(${RYTHE_DIR_ROOT}/${SUBMODULE_PATH})
             set_target_properties(${SUBMODULE_NAME} PROPERTIES FOLDER ${SUBMODULE_DIR})
 
             # No need to add as an include path if no headers are present
@@ -82,11 +82,11 @@ if (NOT ${SUBMODULE_COUNT} EQUAL 0)
 
                 message(STATUS "Editor: ${SUBMODULE_EDITOR_NAME} found!")
                 rythe_update_submodule("${SUBMODULE_EDITOR_PATH}")
-                add_subdirectory("${SUBMODULE_EDITOR_PATH}/src/${SUBMODULE_NAME}-editor")
-                set_target_properties("${SUBMODULE_NAME}-editor" PROPERTIES FOLDER ${SUBMODULE_EDITOR_DIR})
+                add_subdirectory("${SUBMODULE_EDITOR_PATH}")
+                set_target_properties("${SUBMODULE_EDITOR_NAME}" PROPERTIES FOLDER ${SUBMODULE_EDITOR_DIR})
 
-                list(APPEND RYTHE_LIBS_ALL "${SUBMODULE_NAME}-editor")
-                list(APPEND RYTHE_LIBS_EDITOR "${SUBMODULE_NAME}-editor")
+                list(APPEND RYTHE_LIBS_ALL "${SUBMODULE_EDITOR_NAME}")
+                list(APPEND RYTHE_LIBS_EDITOR "${SUBMODULE_EDITOR_NAME}")
                 list(APPEND RYTHE_INCLUDE_ALL "${RYTHE_DIR_ROOT}/${SUBMODULE_EDITOR_PATH}/src")
                 list(APPEND RYTHE_INCLUDE_EDITOR "${RYTHE_DIR_ROOT}/${SUBMODULE_EDITOR_PATH}/src")
                 list(APPEND RYTHE_DEFINITIONS "RYTHE_${SUBMODULE_VARIABLE_NAME}_EDITOR")
@@ -123,8 +123,12 @@ endforeach()
 # so that it properly updates in the root scope.
 set(RYTHE_LIBS_ALL ${RYTHE_LIBS_ALL} PARENT_SCOPE)
 set(RYTHE_LIBS_ENGINE ${RYTHE_LIBS_ENGINE} PARENT_SCOPE)
+set(RYTHE_LIBS_THIRD_PARTY ${RYTHE_LIBS_THIRD_PARTY} PARENT_SCOPE)
+
 set(RYTHE_INCLUDE_ALL ${RYTHE_INCLUDE_ALL} PARENT_SCOPE)
 set(RYTHE_INCLUDE_ENGINE ${RYTHE_INCLUDE_ENGINE} PARENT_SCOPE)
+set(RYTHE_INCLUDE_THIRD_PARTY ${RYTHE_INCLUDE_THIRD_PARTY} PARENT_SCOPE)
+
 set(RYTHE_DEFINITIONS ${RYTHE_DEFINITIONS} PARENT_SCOPE)
 
 set(RYTHE_ENABLED_MODULE_NAMES ${RYTHE_ENABLED_MODULE_NAMES} PARENT_SCOPE)

--- a/tests/todo.txt
+++ b/tests/todo.txt
@@ -1,1 +1,0 @@
-Write tests for the build system


### PR DESCRIPTION
adds the add_third_party macro that adds in a third party dependency, if not already added. This allows modules to easily & safely include/link third party dependencies without worrying about other modules adding the same dependency 